### PR TITLE
Set YAML coder explicitly to handle legacy databases

### DIFF
--- a/app/models/comfy/cms/fragment.rb
+++ b/app/models/comfy/cms/fragment.rb
@@ -6,7 +6,7 @@ class Comfy::Cms::Fragment < ActiveRecord::Base
 
   has_many_attached :attachments
 
-  serialize :content
+  serialize :content, coder: YAML
 
   attr_reader :files
 

--- a/app/models/comfy/cms/revision.rb
+++ b/app/models/comfy/cms/revision.rb
@@ -4,7 +4,7 @@ class Comfy::Cms::Revision < ActiveRecord::Base
 
   self.table_name = "comfy_cms_revisions"
 
-  serialize :data
+  serialize :data, coder: YAML
 
   # -- Relationships --------------------------------------------------------
   belongs_to :record, polymorphic: true


### PR DESCRIPTION
Fixes the issues with having legacy databases use YAML encoder for serialized attributes
